### PR TITLE
Disable del on empty strings being treated as an EOF interrupt

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -266,7 +266,7 @@ func (o *Operation) ioloop() {
 				o.t.Bell()
 			}
 		case CharDelete:
-			if o.buf.Len() > 0 || !o.IsNormalMode() {
+			if o.buf.Len() > 0 || !o.IsNormalMode() || o.cfg.NoEofOnEmptyDelete {
 				o.t.KickRead()
 				if !o.buf.Delete() {
 					o.t.Bell()
@@ -274,18 +274,16 @@ func (o *Operation) ioloop() {
 				break
 			}
 
-			if !o.cfg.NoEofOnEmptyDelete {
-				// treat as EOF
-				if !o.cfg.UniqueEditLine {
-					o.buf.WriteString(o.cfg.EOFPrompt + "\n")
-				}
-				o.buf.Reset()
-				isUpdateHistory = false
-				o.history.Revert()
-				o.errchan <- io.EOF
-				if o.cfg.UniqueEditLine {
-					o.buf.Clean()
-				}
+			// treat as EOF
+			if !o.cfg.UniqueEditLine {
+				o.buf.WriteString(o.cfg.EOFPrompt + "\n")
+			}
+			o.buf.Reset()
+			isUpdateHistory = false
+			o.history.Revert()
+			o.errchan <- io.EOF
+			if o.cfg.UniqueEditLine {
+				o.buf.Clean()
 			}
 		case CharInterrupt:
 			if o.IsSearchMode() {

--- a/operation.go
+++ b/operation.go
@@ -274,16 +274,18 @@ func (o *Operation) ioloop() {
 				break
 			}
 
-			// treat as EOF
-			if !o.cfg.UniqueEditLine {
-				o.buf.WriteString(o.cfg.EOFPrompt + "\n")
-			}
-			o.buf.Reset()
-			isUpdateHistory = false
-			o.history.Revert()
-			o.errchan <- io.EOF
-			if o.cfg.UniqueEditLine {
-				o.buf.Clean()
+			if !o.cfg.NoEofOnEmptyDelete {
+				// treat as EOF
+				if !o.cfg.UniqueEditLine {
+					o.buf.WriteString(o.cfg.EOFPrompt + "\n")
+				}
+				o.buf.Reset()
+				isUpdateHistory = false
+				o.history.Revert()
+				o.errchan <- io.EOF
+				if o.cfg.UniqueEditLine {
+					o.buf.Clean()
+				}
 			}
 		case CharInterrupt:
 			if o.IsSearchMode() {

--- a/readline.go
+++ b/readline.go
@@ -43,7 +43,7 @@ type Config struct {
 	MaxCompleteLines int
 
 	// NoEofOnEmptyDelete disables the ^D interrupt when del is pressed on an empty readline buffer
-	NoEofOnEmptyDelete  bool
+	NoEofOnEmptyDelete bool
 
 	// Output will transform the input buffer for display i.e (highlighting)
 	Output func(string) string

--- a/readline.go
+++ b/readline.go
@@ -42,6 +42,9 @@ type Config struct {
 	// Complete line limit
 	MaxCompleteLines int
 
+	// NoEofOnEmptyDelete disables the ^D interrupt when del is pressed on an empty readline buffer
+	NoEofOnEmptyDelete  bool
+
 	// Output will transform the input buffer for display i.e (highlighting)
 	Output func(string) string
 


### PR DESCRIPTION
Config property added as "true" to disable, to preserve backwards compatibility