### PR TITLE
Support xterm style ctrl+left/right word movement

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -105,9 +105,19 @@ func escapeExKey(key *escapeKeyPair) rune {
 	case 'Z':
 		r = MetaShiftTab
 	case 'D':
-		r = CharBackward
+		switch key.attr {
+		case "1;5":
+			r = MetaBackward
+		default:
+			r = CharBackward
+		}
 	case 'C':
-		r = CharForward
+		switch key.attr {
+		case "1;5":
+			r = MetaForward
+		default:
+			r = CharForward
+		}
 	case 'A':
 		r = CharPrev
 	case 'B':


### PR DESCRIPTION
Support `ctrl+left`/`ctrl+right` word movement support for terminal emulators that use  
 `^[[1;5D`/`^[[1;5C`